### PR TITLE
Compatibility for Unifi USG - emulating NoIP Server

### DIFF
--- a/private/filter.class.php
+++ b/private/filter.class.php
@@ -63,7 +63,8 @@ class filter {
       
         //set local variables
         worker::setHostname($get['hostname']);
-        worker::setIPv4($get['ip']);
+        if isset($get['myip']) {
+        worker::setIPv4(isset($get['myip'])==true ? $get['myip'] : $get['ip']);
         worker::setIPv6($get['ip6']);
         
         if (config::allowedDynDNSDomains!==false && count(config::allowedDynDNSDomains)) {

--- a/private/filter.class.php
+++ b/private/filter.class.php
@@ -63,7 +63,6 @@ class filter {
       
         //set local variables
         worker::setHostname($get['hostname']);
-        if isset($get['myip']) {
         worker::setIPv4(isset($get['myip'])==true ? $get['myip'] : $get['ip']);
         worker::setIPv6($get['ip6']);
         

--- a/www/nic/.htaccess
+++ b/www/nic/.htaccess
@@ -1,0 +1,9 @@
+#RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^([^\.]+)$ $1.php [NC,L]
+<IfModule mod_rewrite.c>
+  RewriteEngine on
+  RewriteRule ^updateDNS updatedns.php [L]
+  #SetEnvIf Authorization „(.*)“ HTTP_AUTHORIZATION=$1
+  RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+</IfModule>

--- a/www/nic/update.php
+++ b/www/nic/update.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @author Tim Weyand <https://www.weyand.biz>
+ * @copyright 2017 - Tim Weyand
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @version 1.1 edited by CptNemooo
+ */
+include __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'private'.DIRECTORY_SEPARATOR.'autoload.class.php';
+
+$result = website\weyand\dyndns\worker::init()->setRecords();


### PR DESCRIPTION
The Unifi USG unfortunately does not allow custom Update URLs, however NoIP Update URLs are quite similar to those of this script. 
Added support for /nic/update?hostname=xxx&myip=x.x.x.x
IPv6 Updates are not yet implemented...